### PR TITLE
fix: incorrect JSON extraction in string replacement logic

### DIFF
--- a/src/components/PageLatex.js
+++ b/src/components/PageLatex.js
@@ -125,7 +125,7 @@ export default function PageLatex({ latex, className, date = '2024, 5, 11' }) {
           if (matches) {
             for (const match of matches) {
               // Remove the *** markers with { and } for JSON.parse
-              const json = match.replace('***', '{').replace('***', '}');
+              const json = match.slice(3, -3);
               let obj;
 
               try {


### PR DESCRIPTION
noticed an issue where `replace('***', ...)` was only updating the first occurrence, resulting in malformed JSON like `'{**{"type":"picture"}***'`.  

updated the logic to correctly extract the JSON using `match.slice(3, -3)` instead. 

p.s. this ensures the entire string is properly parsed and avoids invalid JSON.